### PR TITLE
Legg til knapp for å sende ny søknad

### DIFF
--- a/app/components/soknad-list/NyesteInnsendtSøknadStatus.tsx
+++ b/app/components/soknad-list/NyesteInnsendtSøknadStatus.tsx
@@ -18,6 +18,7 @@ export function NyesteInnsendtSøknadStatus({ soknad }: IProps) {
 
   const ettersendingUrl = `${getEnv("DP_BRUKERDIALOG_URL")}/${søknadId}/ettersending`;
   const kvitteringUrl = `${getEnv("DP_BRUKERDIALOG_URL")}/${søknadId}/kvittering`;
+  const nySøknadUrl = `${getEnv("DP_BRUKERDIALOG_URL")}`;
   const innsendtDato = new Date(innsendtTimestamp);
   const estimertSvarFraDato = addWeeks(innsendtDato, 6);
   const estimertSvarTilDato = addWeeks(innsendtDato, 7);
@@ -57,6 +58,9 @@ export function NyesteInnsendtSøknadStatus({ soknad }: IProps) {
         </ExternalLink>
         <ExternalLink to={kvitteringUrl} asButtonVariant="secondary" size="small">
           {getAppText("fullfort-soknad.se-soknad.knapp-tekst")}
+        </ExternalLink>
+        <ExternalLink to={nySøknadUrl} asButtonVariant="secondary" size="small">
+          Send ny søknad
         </ExternalLink>
       </nav>
 


### PR DESCRIPTION
Hvis saken egentlig er ferdigbehandlet, vil infoboksen nå lure folk, siden den blir værende. Vi legger derfor på en knapp som sender deg til hovedsiden av søknaden, sånn at du enkelt kan søke på nytt.

<img width="1282" height="1087" alt="image" src="https://github.com/user-attachments/assets/03a6e73c-fbfe-4633-9287-e96dce728077" />
